### PR TITLE
Alias global field name fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .vscode
-
+.python_env/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/quera_ahs_utils/ir.py
+++ b/src/quera_ahs_utils/ir.py
@@ -162,25 +162,25 @@ class braket_to_quera:
     def get_rabi_frequency_amplitude(driving: braket_ir.DrivingField):
         field = braket_to_quera.get_global_field(driving.amplitude)
         return RabiFrequencyAmplitude(
-            **{"global":braket_to_quera.get_global_field(driving.amplitude)}
+            global_=braket_to_quera.get_global_field(driving.amplitude)
         )
         
     @staticmethod
     def get_rabi_frequency_phase(driving: braket_ir.DrivingField):
         return RabiFrequencyPhase(
-            **{"global":braket_to_quera.get_global_field(driving.phase)}
+            global_=braket_to_quera.get_global_field(driving.phase)
         )
     
     @staticmethod
     def get_detuning(driving: braket_ir.DrivingField, shifting: Optional[braket_ir.ShiftingField]):
         if shifting == None:
             return Detuning(
-                **{"global":braket_to_quera.get_global_field(driving.detuning)}
+                global_=braket_to_quera.get_global_field(driving.detuning)
             )
         else:
             return Detuning(
-                **{"global":braket_to_quera.get_global_field(driving.detuning),
-                "local":braket_to_quera.get_local_field(shifting.magnitude)}
+                global_=braket_to_quera.get_global_field(driving.detuning),
+                local=braket_to_quera.get_local_field(shifting.magnitude)
             )
 
     @staticmethod

--- a/src/quera_ahs_utils/quera_ir/capabilities.py
+++ b/src/quera_ahs_utils/quera_ir/capabilities.py
@@ -37,6 +37,7 @@ class RydbergCapabilities(BaseModel):
     local: RydbergLocalCapabilities
 
     class Config:
+        allow_population_by_field_name = True
         fields = {
             'global_': 'global'
         }

--- a/src/quera_ahs_utils/quera_ir/task_results.py
+++ b/src/quera_ahs_utils/quera_ir/task_results.py
@@ -62,7 +62,7 @@ class QuEraTaskResults(BaseModel):
     task_status: QuEraTaskStatusCode = QuEraTaskStatusCode.Failed
     shot_outputs: conlist(QuEraShotResult, min_items=0) = []
     
-    def export_as_probabilties(self) -> TaskProbabilities:
+    def export_as_probabilities(self) -> TaskProbabilities:
         """converts from shot results to probabilities
 
         Returns:

--- a/src/quera_ahs_utils/quera_ir/task_specification.py
+++ b/src/quera_ahs_utils/quera_ir/task_specification.py
@@ -36,6 +36,7 @@ class RabiFrequencyAmplitude(BaseModel):
     global_: GlobalField
     
     class Config:
+        allow_population_by_field_name = True
         fields = {
             'global_': 'global'
         }
@@ -47,15 +48,18 @@ class RabiFrequencyAmplitude(BaseModel):
         global_time_resolution = task_capabilities.capabilities.rydberg.global_.time_resolution
         global_value_resolution =  task_capabilities.capabilities.rydberg.global_.rabi_frequency_resolution
         
-        return RabiFrequencyAmplitude(**{"global":GlobalField(
+        return RabiFrequencyAmplitude(
+            global_ = GlobalField(
                 times = discretize_list(self.global_.times, global_time_resolution),
-                values = discretize_list(self.global_.values, global_value_resolution))} 
-            )
+                values = discretize_list(self.global_.values, global_value_resolution)
+            ) 
+        )
 
 class RabiFrequencyPhase(BaseModel):
     global_: GlobalField
     
     class Config:
+        allow_population_by_field_name = True
         fields = {
             'global_': 'global'
         }
@@ -67,9 +71,10 @@ class RabiFrequencyPhase(BaseModel):
         global_time_resolution = task_capabilities.capabilities.rydberg.global_.time_resolution
         global_value_resolution =  task_capabilities.capabilities.rydberg.global_.phase_resolution
         
-        return RabiFrequencyPhase(**{"global":GlobalField(
-                times = discretize_list(self.global_.times, global_time_resolution),
-                values = discretize_list(self.global_.values, global_value_resolution))}               
+        return RabiFrequencyPhase(global_=GlobalField(
+                    times = discretize_list(self.global_.times, global_time_resolution),
+                    values = discretize_list(self.global_.values, global_value_resolution)
+                )
             )
     
 class Detuning(BaseModel):
@@ -77,6 +82,7 @@ class Detuning(BaseModel):
     local: Optional[LocalField]
     
     class Config:
+        allow_population_by_field_name = True
         fields = {
             'global_': 'global'
         }
@@ -97,12 +103,13 @@ class Detuning(BaseModel):
                 )
 
 
-        return Detuning(**{"global":GlobalField(
-                times = discretize_list(self.global_.times, global_time_resolution),
-                values = discretize_list(self.global_.values, global_value_resolution)
-            ),"local": self.local
-            }
-        )
+        return Detuning(
+                global_ = GlobalField(
+                    times = discretize_list(self.global_.times, global_time_resolution),
+                    values = discretize_list(self.global_.values, global_value_resolution)
+                ),
+                local = self.local
+            )
     
 class RydbergHamiltonian(BaseModel):
     rabi_frequency_amplitude: RabiFrequencyAmplitude


### PR DESCRIPTION
you can now use `global_` in the constructor or quera IR objects. 